### PR TITLE
cmd/bpf2go: allow setting output dir

### DIFF
--- a/cmd/bpf2go/compile_test.go
+++ b/cmd/bpf2go/compile_test.go
@@ -151,11 +151,7 @@ nothing:
 func mustWriteTempFile(t *testing.T, name, contents string) string {
 	t.Helper()
 
-	tmp, err := os.MkdirTemp("", "bpf2go")
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { os.RemoveAll(tmp) })
+	tmp := t.TempDir()
 
 	tmpFile := filepath.Join(tmp, name)
 	if err := os.WriteFile(tmpFile, []byte(contents), 0660); err != nil {

--- a/cmd/bpf2go/main.go
+++ b/cmd/bpf2go/main.go
@@ -71,8 +71,8 @@ var targetByGoArch = map[string]target{
 	"sparc64":     {"bpfeb", "sparc"},
 }
 
-func run(stdout io.Writer, pkg, outputDir string, args []string) (err error) {
-	b2g, err := newB2G(stdout, pkg, outputDir, args)
+func run(stdout io.Writer, pkg string, args []string) (err error) {
+	b2g, err := newB2G(stdout, pkg, args)
 	switch {
 	case err == nil:
 		return b2g.convertAll()
@@ -114,11 +114,10 @@ type bpf2go struct {
 	makeBase string
 }
 
-func newB2G(stdout io.Writer, pkg, outputDir string, args []string) (*bpf2go, error) {
+func newB2G(stdout io.Writer, pkg string, args []string) (*bpf2go, error) {
 	b2g := &bpf2go{
-		stdout:    stdout,
-		pkg:       pkg,
-		outputDir: outputDir,
+		stdout: stdout,
+		pkg:    pkg,
 	}
 
 	fs := flag.NewFlagSet("bpf2go", flag.ContinueOnError)
@@ -136,6 +135,7 @@ func newB2G(stdout io.Writer, pkg, outputDir string, args []string) (*bpf2go, er
 	fs.Var(&b2g.cTypes, "type", "`Name` of a type to generate a Go declaration for, may be repeated")
 	fs.BoolVar(&b2g.skipGlobalTypes, "no-global-types", false, "Skip generating types for map keys and values, etc.")
 	fs.StringVar(&b2g.outputStem, "output-stem", "", "alternative stem for names of generated files (defaults to ident)")
+	fs.StringVar(&b2g.outputDir, "output", "", "Output directory in which to write Go files (defaults to pwd)")
 
 	fs.SetOutput(b2g.stdout)
 	fs.Usage = func() {
@@ -146,6 +146,14 @@ func newB2G(stdout io.Writer, pkg, outputDir string, args []string) (*bpf2go, er
 	}
 	if err := fs.Parse(args); err != nil {
 		return nil, err
+	}
+
+	if b2g.outputDir == "" {
+		outputDir, err := os.Getwd()
+		if err != nil {
+			return nil, fmt.Errorf("error getting current working dir: %w", err)
+		}
+		b2g.outputDir = outputDir
 	}
 
 	if b2g.pkg == "" {
@@ -485,13 +493,7 @@ func collectTargets(targets []string) (map[target][]string, error) {
 }
 
 func main() {
-	outputDir, err := os.Getwd()
-	if err != nil {
-		fmt.Fprintln(os.Stderr, "Error:", err)
-		os.Exit(1)
-	}
-
-	if err := run(os.Stdout, os.Getenv("GOPACKAGE"), outputDir, os.Args[1:]); err != nil {
+	if err := run(os.Stdout, os.Getenv("GOPACKAGE"), os.Args[1:]); err != nil {
 		fmt.Fprintln(os.Stderr, "Error:", err)
 		os.Exit(1)
 	}

--- a/cmd/bpf2go/main.go
+++ b/cmd/bpf2go/main.go
@@ -151,7 +151,7 @@ func newB2G(stdout io.Writer, pkg string, args []string) (*bpf2go, error) {
 	if b2g.outputDir == "" {
 		outputDir, err := os.Getwd()
 		if err != nil {
-			return nil, fmt.Errorf("error getting current working dir: %w", err)
+			return nil, fmt.Errorf("unable to get current working dir: %w", err)
 		}
 		b2g.outputDir = outputDir
 	}


### PR DESCRIPTION
## Description
Allow setting an output directory for the `bpf2go` command.

### Usage
An optional `-output` flag has been added. If not specified, then default to the current behavior of using `os.Getwd()`.

I have tested this locally on my machine using:


Happy to close or keep a fork if this isn't something that's deemed needed/useful.